### PR TITLE
fix: move from node 16 to 14 because of failing docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 RUN npm install --only=prod && npm run package
 
-FROM node:16-alpine
+FROM node:14-alpine
 
 # We need to copy entire node modules as some dependencies (@npmcli/run-script) cannot be packaged
 # and need to be used by dist as external dependency

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:16 as builder
+FROM node:14 as builder
 
 COPY ./ /app
 WORKDIR /app
 
-RUN npm install --omit=dev && npm run package
+RUN npm install --only=prod && npm run package
 
 FROM node:16-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM node:16 as builder
 COPY ./ /app
 WORKDIR /app
 
-RUN npm install && npm run package
+RUN npm install --omit=dev && npm run package
 
 FROM node:16-alpine
 
-# We need to copy entire node modules as some dependencies (@npmcli/run-script) cannot be packaged 
+# We need to copy entire node modules as some dependencies (@npmcli/run-script) cannot be packaged
 # and need to be used by dist as external dependency
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14 as builder
 COPY ./ /app
 WORKDIR /app
 
-RUN npm install --only=prod && npm run package
+RUN npm install && npm run package
 
 FROM node:14-alpine
 


### PR DESCRIPTION
**Description**
Fixes the dev dependencies build error https://github.com/asyncapi/github-action-for-generator/issues/232#issuecomment-1218155509

**Related issue(s)**
See also https://github.com/asyncapi/github-action-for-generator/issues/232