### PR TITLE
chore: add asyncapi tool info file

### DIFF
--- a/.asyncapi-tool
+++ b/.asyncapi-tool
@@ -1,0 +1,6 @@
+title: GitHub Action for Generator
+filters:
+    technology:
+        - AsyncAPI Generator
+    categories:
+        - github-actions


### PR DESCRIPTION
Adding file based on https://github.com/asyncapi/website/issues/383

tl;dr the idea is that tools list on website will soon work basing not only on manual process, where people manually add their tools to list, but also automated process where people instead of opening a PR to website, will be able to just add a config file to their public repo.