### PR TITLE
fix: remove ncc packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM node:14 as builder
+FROM node:16 as builder
 
 COPY ./ /app
 WORKDIR /app
 
-RUN npm install && npm run package
+RUN npm install
 
-FROM node:14-alpine
+FROM node:16-alpine
 
-# We need to copy entire node modules as some dependencies (@npmcli/run-script) cannot be packaged
-# and need to be used by dist as external dependency
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/dist ./dist
+COPY --from=builder /app ./
 
-ENTRYPOINT [ "node", "/dist/index.js" ]
+ENTRYPOINT [ "node", "/lib/index.js" ]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jobs:
       
     #In case you do not want to use defaults, you for example want to use different template
     - name: Generating HTML from my AsyncAPI document
-      uses: docker://asyncapi/github-action-for-generator:2.0.0
+      uses: docker://asyncapi/github-action-for-generator:2.0.0 #always use latest tag as each is pushed to docker
       with:
         template: '@asyncapi/html-template@0.9.0'  #In case of template from npm, because of @ it must be in quotes
         filepath: docs/api/my-asyncapi.yml

--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
   "name": "github-action-for-generator",
   "version": "2.1.11",
   "description": "GitHub action to generate all the things form your AsyncAPI document",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "scripts": {
     "release": "semantic-release",
     "lint": "eslint --max-warnings 0 --config .eslintrc lib",
-    "package": "ncc build lib/index.js -o dist -s --external=\"@npmcli/run-script\"",
     "test": "jest --coverage",
     "start": "node lib/index.js",
     "generate:assets": "echo 'No additional assets need to be generated at the moment'",


### PR DESCRIPTION
Fixes https://github.com/asyncapi/github-action-for-generator/issues/286
Fixes https://github.com/asyncapi/generator/issues/904

Again because of some issue with `ncc` bundling there are some weird errors related to transpilation.

The thing is that since docker was introduced we do not really need `ncc` 🤦🏼 as we have`node_modules` anyway. I completely forgot about it 😄 
